### PR TITLE
Fixed issue 87 by including 0-9 in the regular expression on line 173

### DIFF
--- a/pyeda/parsing/boolexpr.py
+++ b/pyeda/parsing/boolexpr.py
@@ -170,7 +170,7 @@ class BoolExprLexer(RegexLexer):
             (r"\bImplies\b", keyword),
             (r"\bNot\b", keyword),
 
-            (r"[a-zA-Z][a-zA-Z_0-9]*(?:\.[a-zA-Z][a-zA-Z_]*)*(?:\[\d+\])*", name),
+            (r"[a-zA-Z][a-zA-Z_0-9]*(?:\.[a-zA-Z][a-zA-Z_0-9]*)*(?:\[\d+\])*", name),
             (r"\b[01]\b", integer),
 
             (r"=>", operator),


### PR DESCRIPTION
Fixed issue 87 regarding parsing variables that contain numbers found in an expression string when using 'expr'
