### PR TITLE
Update 2llm.rst

### DIFF
--- a/doc/source/2llm.rst
+++ b/doc/source/2llm.rst
@@ -33,7 +33,7 @@ Consider the three-input function
 
 To use Espresso to perform minimization::
 
-   >>> f1m, = espresso_exprs(f1)
+   >>> f1m, = espresso_exprs(f1.to_dnf())
    >>> f1m
    Or(And(~a, ~b), And(a, b), And(~b, c))
 


### PR DESCRIPTION
Convert f1 to DNF before sending to espresso_exprs? Because I was getting "ValueError: expected a DNF expression" without it.