### PR TITLE
Add support for unicode variable name.

### DIFF
--- a/pyeda/boolalg/boolfunc.py
+++ b/pyeda/boolalg/boolfunc.py
@@ -91,8 +91,8 @@ def var(name, index=None):
         if tname is not str:
             fstr = "expected name to be a str, got {0.__name__}"
             raise TypeError(fstr.format(tname))
-        if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", name):
-            fstr = "expected name to match [a-zA-Z][a-zA-Z0-9_]*, got {}"
+        if not re.match(r"^[^\d\W]\w*$", name, flags=re.UNICODE):
+            fstr = "expected name to match (letter|'_')(letter|digit|'_')*, got {}"
             raise ValueError(fstr.format(name))
 
     if index is None:


### PR DESCRIPTION
Since this library is for Python 3, it's nice to have support for unicode variable name.