### PR TITLE
Remove variable name restrictions

### DIFF
--- a/pyeda/boolalg/boolfunc.py
+++ b/pyeda/boolalg/boolfunc.py
@@ -91,9 +91,6 @@ def var(name, index=None):
         if tname is not str:
             fstr = "expected name to be a str, got {0.__name__}"
             raise TypeError(fstr.format(tname))
-        if not re.match(r"^[^\d\W]\w*$", name, flags=re.UNICODE):
-            fstr = "expected name to match (letter|'_')(letter|digit|'_')*, got {}"
-            raise ValueError(fstr.format(name))
 
     if index is None:
         indices = tuple()

--- a/pyeda/boolalg/test/test_boolfunc.py
+++ b/pyeda/boolalg/test/test_boolfunc.py
@@ -25,7 +25,6 @@ def test_var():
     assert_raises(TypeError, var, 42)
     assert_raises(ValueError, var, tuple())
     assert_raises(TypeError, var, (42, ))
-    assert_raises(ValueError, var, ('foo#bar', ))
     assert_raises(TypeError, var, 'a', 'index')
     assert_raises(TypeError, var, 'a', ('index', ))
     assert_raises(ValueError, var, 'a', (-1, ))


### PR DESCRIPTION
Variables are no longer tested against a regular expression
restricting them to alphanumeric names that match (letter|'_')(letter|digit|'_')*