### PR TITLE
Python 3.10: Use collections.abc.Sequence instead of collections.Sequence

### DIFF
--- a/pyeda/boolalg/bfarray.py
+++ b/pyeda/boolalg/bfarray.py
@@ -1029,10 +1029,10 @@ def _int2farray(ftype, num, length=None):
 
 def _itemize(objs):
     """Recursive helper function for farray."""
-    if not isinstance(objs, collections.Sequence):
+    if not isinstance(objs, collections.abc.Sequence):
         raise TypeError("expected a sequence of Function")
 
-    isseq = [isinstance(obj, collections.Sequence) for obj in objs]
+    isseq = [isinstance(obj, collections.abc.Sequence) for obj in objs]
     if not any(isseq):
         ftype = None
         for obj in objs:


### PR DESCRIPTION
`collections.Sequence` was moved to `collections.abc.Sequence` and with Python 3.10 the grace period has ended.

This PR fixes the wrong usages, introducing compatibility with Python 3.10.

See also: https://stackoverflow.com/questions/69596494/unable-to-import-freegames-python-package-attributeerror-module-collections