### PR TITLE
Fixing None type has no update method

### DIFF
--- a/pyeda/boolalg/expr.py
+++ b/pyeda/boolalg/expr.py
@@ -743,7 +743,7 @@ class Expression(boolfunc.Function):
             if _ASSUMPTIONS:
                 aupnt = _assume2point()
                 soln = _backtrack(self.restrict(aupnt))
-                soln.update(aupnt)
+                if soln != None: soln.update(aupnt)
                 return soln
             else:
                 return _backtrack(self)


### PR DESCRIPTION
Sometimes "_backtrack(self.restrict(aupnt)) "returns None since no solutions were found, Hence "soln.update(aupnt)" will raize an error. A quick fix is to check whether "soln" is None before calling "update(aupnt)".