### PR TITLE
DocFix - 2LLM - missing prime symbol

### DIFF
--- a/doc/source/2llm.rst
+++ b/doc/source/2llm.rst
@@ -24,7 +24,7 @@ Minimize Boolean Expressions
 ============================
 
 Consider the three-input function
-:math:`f_{1} = a \cdot b' \cdot c' + a' \cdot b' \cdot c + a \cdot b' \cdot c + a \cdot b \cdot c + a \cdot b \cdot c'`
+:math:`f_{1} = a' \cdot b' \cdot c' + a' \cdot b' \cdot c + a \cdot b' \cdot c + a \cdot b \cdot c + a \cdot b \cdot c'`
 
 ::
 


### PR DESCRIPTION
Hi there!

There was a missing prime symbol to make it consistent with the code below.