### PR TITLE
Get rid of errors in espresso compilation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ ESPRESSO = dict(
         pjoin("thirdparty", "espresso", "src", "verify.c"),
         pjoin("pyeda", "boolalg", "espressomodule.c"),
     ],
+    extra_compile_args=["-Wno-incompatible-pointer-types"],
 )
 
 # exprnode C extension


### PR DESCRIPTION
The source code of espresso is not entirely compliant, for example:

```c
    qsort((char *) (T+2), ncubes, sizeof(set *), d1_order);
...
int
d1_order(set **a, set **b)
```

note that the last argument of `qsort` must be a function that takes two `const void*`, but `d1_order` is not.

This is technically not compliant to the C standard, but it works well on most machines.

This causes a hard compilation error on my machine. The fix allows pyeda to be installed.