### PR TITLE
Fix GIL handling in picosat memory allocators.

### DIFF
--- a/pyeda/boolalg/picosatmodule.c
+++ b/pyeda/boolalg/picosatmodule.c
@@ -36,19 +36,32 @@ static PyObject *Error;
 inline static void *
 _pymalloc(void *pmgr, size_t nbytes)
 {
-    return PyMem_Malloc(nbytes);
+    void *ptr;
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+    ptr = PyMem_Malloc(nbytes);
+    PyGILState_Release(gstate);
+    return ptr;
 }
 
 inline static void *
 _pyrealloc(void *pmgr, void *p, size_t old, size_t new)
 {
-    return PyMem_Realloc(p, new);
+    void *ptr;
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+    ptr = PyMem_Realloc(p, new);
+    PyGILState_Release(gstate);
+    return ptr;
 }
 
 inline static void
 _pyfree(void *pmgr, void *p, size_t nbytes)
 {
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
     PyMem_Free(p);
+    PyGILState_Release(gstate);
 }
 
 


### PR DESCRIPTION
The custom memory allocators in `picosatmodule.c` were calling PyMem_Malloc, PyMem_Realloc, and PyMem_Free without holding the GIL. This could lead to a segfault when picosat_sat, which releases the GIL, calls these allocators.

This commit fixes the issue by acquiring the GIL before calling PyMem_ functions and releasing it afterwards in the custom memory allocators.

Fixes #195