### PR TITLE
Fix Reference Counting (Use-After-Free) Bugs for PyTuple_SetItem

### DIFF
--- a/pyeda/boolalg/espressomodule.c
+++ b/pyeda/boolalg/espressomodule.c
@@ -218,7 +218,6 @@ _esprcov2pycov(int ninputs, int noutputs, set_family_t *F)
         for (i = 0; i < noutputs; i++) {
             pylong = PyLong_FromLong((long) GETOUTPUT(p, i));
             if (PyTuple_SetItem(pyouts, i, pylong) < 0) {
-                Py_DECREF(pylong);
                 goto decref_pyins_pyouts;
             }
         }
@@ -232,7 +231,6 @@ _esprcov2pycov(int ninputs, int noutputs, set_family_t *F)
         }
         if (PyTuple_SetItem(pyimpl, 1, pyouts) < 0) {
             Py_DECREF(pyimpl);
-            Py_DECREF(pyouts);
             goto decref_pyset;
         }
         if (PySet_Add(pyset, pyimpl) < 0) {

--- a/pyeda/boolalg/espressomodule.c
+++ b/pyeda/boolalg/espressomodule.c
@@ -205,7 +205,6 @@ _esprcov2pycov(int ninputs, int noutputs, set_family_t *F)
         for (i = 0; i < ninputs; i++) {
             pylong = PyLong_FromLong((long) GETINPUT(p, i));
             if (PyTuple_SetItem(pyins, i, pylong) < 0) {
-                Py_DECREF(pylong);
                 Py_DECREF(pyins);
                 goto decref_pyset;
             }


### PR DESCRIPTION
### Related Issues

https://github.com/cjdrake/pyeda/issues/199

### Description

A reference to item is incorrectly decremented after a failed PyTuple_SetItem call, leading to a potential use-after-free vulnerability or double-decrement crash.

### Affected Code

https://github.com/cjdrake/pyeda/blob/6ba0979a51d7f610832469570981e233a7dbcf79/pyeda/boolalg/espressomodule.c#L207-L211

https://github.com/cjdrake/pyeda/blob/6ba0979a51d7f610832469570981e233a7dbcf79/pyeda/boolalg/espressomodule.c#L221-L223

https://github.com/cjdrake/pyeda/blob/6ba0979a51d7f610832469570981e233a7dbcf79/pyeda/boolalg/espressomodule.c#L234-L238

### Root Cause

[PyTuple_SetItem Source Code](https://github.com/python/cpython/blob/a126893fa80c4ee5f0bac8a84a49491c19edd511/Objects/tupleobject.c#L118)

[PyTuple_SetItem Document](https://docs.python.org/3/c-api/tuple.html#c.PyTuple_SetItem)

[PyList_SetItem Python Forum Discussion](https://discuss.python.org/t/proper-handling-of-pylist-setitem-return-value-and-reference-stealing-in-cpython-c-extensions/105805)

Therefore, whether the function succeeds or fails, it will steal a reference count of the third argument. It must not call `Py_XDECREF/Py_DECREF` in case of failure.

### Evidence：Reference Counting and Ownership in CPython Native API

#### Borrowed Reference
A borrowed reference is a reference obtained from an object that you don't own. You don't need to decrement its reference count when you're done with it, but you must ensure the object stays alive while you're using it (e.g., by creating an owned reference with `Py_INCREF` if necessary). Borrowed references are typically returned by functions like `PyList_GetItem()`, which returns an item from a list without incrementing its reference count.

#### New Reference
A new reference (also called an "owned reference") is a reference that you have ownership of. When you receive a new reference from a function (such as `PyObject_New()` or `Py_BuildValue()`), you are responsible for calling `Py_DECREF()` on it when you no longer need it to properly decrement its reference count. Failure to do so causes memory leaks.

#### Stolen Reference (Stealing)

A stolen reference is when a function takes ownership of a reference you pass to it. When you pass an object reference to a function that "steals" it, you no longer own that reference, and you should **not** call `Py_DECREF()` on it afterward. The function assumes full responsibility for managing the reference count of that object.

##### Example: `PyTuple_SetItem`

`PyTuple_SetItem` is a classic example of a reference-stealing function. According to the documentation:

> Note This function “steals” a reference to o and discards a reference to an item already in the tuple at the affected position.

However, a critical ambiguity in the documentation is that it does **not** clearly state whether the reference is stolen in the case of function failure. This is fundamentally an **all-or-nothing problem**: when you pass an object to a stealing function, you must understand whether ownership is unconditionally transferred or only transferred on success.

Looking at the CPython source code clarifies this behavior:

```C
int
PyTuple_SetItem(PyObject *op, Py_ssize_t i, PyObject *newitem)
{
    PyObject **p;
    if (!PyTuple_Check(op) || !_PyObject_IsUniquelyReferenced(op)) {
        Py_XDECREF(newitem);
        PyErr_BadInternalCall();
        return -1;
    }
    if (i < 0 || i >= Py_SIZE(op)) {
        Py_XDECREF(newitem);
        PyErr_SetString(PyExc_IndexError,
                        "tuple assignment index out of range");
        return -1;
    }
    p = ((PyTupleObject *)op) -> ob_item + i;
    Py_XSETREF(*p, newitem);
    return 0;
}
```

As demonstrated in the source code above, `PyTuple_SetItem` unconditionally calls `Py_XDECREF(newitem)` when the type check fails—meaning it **always** steals the reference, even on failure. The function takes ownership of `newitem` regardless of whether it successfully inserts the item into the tuple.

This behavior has serious implications for correct API usage. Consider the following **incorrect** code:

```C
if (PyTuple_SetItem(xxx, yyy, something) < 0) {
    Py_DECREF(something);  // DANGER: Use-After-Free!
}
```

This code is defective because it leads to a **use-after-free** vulnerability. Since `PyTuple_SetItem` already stole the reference (and decremented it on failure via `Py_XDECREF`), the additional `Py_DECREF(something)` in the error-handling block causes a double decrement, potentially leading to an assertion failure in debug builds or memory corruption and crashes in release builds.

The correct pattern is simply:

```C
if (PyTuple_SetItem(a, b, something) < 0) {
    // Do NOT call Py_DECREF on 'something' - the reference was already stolen
    return NULL;  // or handle error appropriately
}
```

In summary, when dealing with stealing functions in the CPython API, you must relinquish all ownership responsibility for the passed reference and **never** decrement it after the call, regardless of the return value. Always consult the source code or thoroughly documented behavior to confirm whether a function truly provides an all-or-nothing stealing guarantee.